### PR TITLE
Fix duplicated LLM calls on theme tree

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.20.1] - 2025-09-16
+
+### Fix
+- Fix code duplication that caused duplicated LLM calls introduced at 0.19.0 (#5)
+
 ## [0.20.0] - 2025-09-15
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "bigdata-research-tools"
-version = "0.20.0"
+version = "0.20.1"
 description = "Bigdata.com API High-Efficiency Tools at Scale"
 readme = "README.md"
 authors = [{ name = "Bigdata.com", email = "support@ravenpack.com" }]

--- a/src/bigdata_research_tools/themes.py
+++ b/src/bigdata_research_tools/themes.py
@@ -330,9 +330,6 @@ class ThemeTree:
             "children": (
                 [child._to_dict() for child in self.children] if self.children else []
             ),
-            "children": (
-                [child._to_dict() for child in self.children] if self.children else []
-            ),
             "keywords": self.keywords,
         }
 
@@ -456,12 +453,6 @@ def generate_risk_tree(
 
     system_prompt = compose_risk_system_prompt_focus(main_theme, focus)
 
-    tree_str = llm.get_response(
-        [{"role": "user", "content": system_prompt}],
-        **ll_model_config.get("kwargs", {}),
-    )
-
-    tree_str = repair_json(tree_str)
     tree_str = llm.get_response(
         [{"role": "user", "content": system_prompt}],
         **ll_model_config.get("kwargs", {}),

--- a/uv.lock
+++ b/uv.lock
@@ -318,7 +318,7 @@ wheels = [
 
 [[package]]
 name = "bigdata-research-tools"
-version = "0.20.0"
+version = "0.20.1"
 source = { virtual = "." }
 dependencies = [
     { name = "bigdata-client" },


### PR DESCRIPTION
Remove some duplicated code introduced on 0.19.0 (#5) that caused theme tree to discard LLM output and generate it again.